### PR TITLE
Fix python 3 compatibility in template

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.standard.env.j2
+++ b/roles/kubernetes/node/templates/kubelet.standard.env.j2
@@ -95,7 +95,7 @@ KUBELET_HOSTNAME="--hostname-override={{ kube_override_hostname }}"
 {% endif %}
 {% set inventory_node_labels = [] %}
 {% if node_labels is defined %}
-{% for labelname, labelvalue in node_labels.iteritems() %}
+{% for labelname, labelvalue in node_labels.items() %}
 {% set dummy = inventory_node_labels.append(labelname + '=' + labelvalue) %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This template file used a python2-only `.iteritems()` call which was removed in python3. 

Fixed this by using `.items()` instead which is available in both python2 and python3.

This should not be a performance issue on python2 since there are generally few node labels per node and the increased memory usage of `.items()` in python2 should not be an issue.